### PR TITLE
增加对./dir模式的路径作正确的修改

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,9 +36,9 @@ hexo.extend.filter.register('after_post_render', function(data){
 		    return elem != '';
 		  });
 		  var srcArray = src.split('/').filter(function(elem){
-		    return elem != '';
+		    return elem != '' && elem != '.';
 		  });
-		  if(linkArray[linkArray.length - 1] == srcArray[0])
+	  if(linkArray[linkArray.length - 1] == srcArray[0])			
 		    srcArray.shift();
           src = srcArray.join('/');
           $(this).attr('src', '/' + link + src);


### PR DESCRIPTION
org-mode中插入图片或者输出图片文件名时需要加 ./ 标识相对地址。如 ’./emacs/test.png ‘ ，如果只输入 'emacs/test.png' 导出时好像不解析成IMG，而增加‘./' 后又会造成解析出错。