### PR TITLE
不判断移除目录项，适应abbrlink及其它规则

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ hexo.extend.filter.register('after_post_render', function(data){
 		  var srcArray = src.split('/').filter(function(elem){
 		    return elem != '' && elem != '.';
 		  });
-	  if(linkArray[linkArray.length - 1] == srcArray[0])			
+	// 		if(linkArray[linkArray.length - 1] == srcArray[0])			
 		    srcArray.shift();
           src = srcArray.join('/');
           $(this).attr('src', '/' + link + src);


### PR DESCRIPTION
当 permalink: :year/:month/:day/:title/ 最后规则不为:title时如：使用abbrlink或者自定义规则时，会造成失效，按实际应用，感觉这个判断不是很必要。