### PR TITLE
Additional Condition on #16 to Respect the Usage in README.

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ hexo.extend.filter.register('after_post_render', function(data){
 		  var srcArray = src.split('/').filter(function(elem){
 		    return elem != '' && elem != '.';
 		  });
-	// 		if(linkArray[linkArray.length - 1] == srcArray[0])			
+		  if(srcArray.length > 1)
 		    srcArray.shift();
           src = srcArray.join('/');
           $(this).attr('src', '/' + link + src);


### PR DESCRIPTION
In #16, the first directory in the path of the picture was removed unconditionally, which seems to be intended for the case of relative paths like `./post-name/image.jpg` or `post-name/image.jpg`.

```javascript
var srcArray = src.split('/').filter(function(elem){
    return elem != '' && elem != '.';
});
//if(linkArray[linkArray.length - 1] == srcArray[0])			
    srcArray.shift();
src = srcArray.join('/');
```

However, in the case of previously specified paths like `image.jpg`, the file name would present as the sole entry in the `srcArray`, resulting in an empty array after the wrong removal. This usage was described in the example section of the README.

For example, the path below shown in README:

```
MacGesture2-Publish
├── apppicker.jpg
├── logo.jpg
└── rules.jpg
MacGesture2-Publish.md
```

```markdown
![logo](logo.png)
```

would be extended to a wrong full path as below:

```html
<img src="/date/MacGesture2-Publish/" />
```

rather than:

```html
<img src="/date/MacGesture2-Publish/logo.png" />
```

To prevent from this, a simple conditional statement before removal does help in this situation.