### PR TITLE
对于以/开头的相对链接不做处理

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,8 @@ hexo.extend.filter.register('after_post_render', function(data){
       $('img').each(function(){
 		// For windows style path, we replace '\' to '/'.
         var src = $(this).attr('src').replace('\\', '/');
-        if(!/http[s]*.*|\/\/.*/.test(src)){
+        if(!/http[s]*.*|\/\/.*/.test(src) &&
+           !/^\s*\//.test(src)) {
 		  // For "about" page, the first part of "src" can't be removed.
 		  // In addition, to support multi-level local directory.
 		  var linkArray = link.split('/').filter(function(elem){


### PR DESCRIPTION
这个插件的本意应该是，写博文的时候， 按照博文的相对路径链接图片：
[[file:artice-xxx/xxx.jpg]]
这会被转换成```<img src="artice-xxx/xxx.jpg" alt="logo">```，然而这个链接不对。这个插件可以很好的处理这种情况。

但是我发现它还会处理类似这样的路径：
```
<img src="/images/emoji/smile.png" alt="logo">
```
以/开头和没有/开头的相对链接区别很大的。博文里出现/开头的相对链接也许是自己故意链接的图片，也许是其它插件生成的图片。

所以我改了下代码，使它不处理这种情况，这样就能和我的插件https://github.com/frapples/hexo-article-emoji   不冲突了。