### PR TITLE
先判断，再替换， 修复 文章中 出现  `<img>`  标签（不含引号）报错的情况

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,24 +27,29 @@ hexo.extend.filter.register('after_post_render', function(data){
       });
 
       $('img').each(function(){
-		// For windows style path, we replace '\' to '/'.
-        var src = $(this).attr('src')&&$(this).attr('src').replace('\\', '/');
-        if(!/http[s]*.*|\/\/.*/.test(src) &&
-           !/^\s*\//.test(src)) {
-		  // For "about" page, the first part of "src" can't be removed.
-		  // In addition, to support multi-level local directory.
-		  var linkArray = link.split('/').filter(function(elem){
-		    return elem != '';
-		  });
-		  var srcArray = src.split('/').filter(function(elem){
-		    return elem != '' && elem != '.';
-		  });
-		  if(srcArray.length > 1)
-		    srcArray.shift();
-          src = srcArray.join('/');
-          $(this).attr('src', config.root + link + src);
-          console.info("update link as:-->"+config.root + link + src);
-        }
+		if ($(this).attr('src')){
+			// For windows style path, we replace '\' to '/'.
+			var src = $(this).attr('src').replace('\\', '/');
+			if(!/http[s]*.*|\/\/.*/.test(src) &&
+			   !/^\s*\//.test(src)) {
+			  // For "about" page, the first part of "src" can't be removed.
+			  // In addition, to support multi-level local directory.
+			  var linkArray = link.split('/').filter(function(elem){
+				return elem != '';
+			  });
+			  var srcArray = src.split('/').filter(function(elem){
+				return elem != '' && elem != '.';
+			  });
+			  if(srcArray.length > 1)
+				srcArray.shift();
+			  src = srcArray.join('/');
+			  $(this).attr('src', config.root + link + src);
+			  console.info&&console.info("update link as:-->"+config.root + link + src);
+			}
+		}else{
+			console.info&&console.info("no src attr, skipped...");
+			console.info&&console.info($(this));
+		}
       });
       data[key] = $.html();
     }

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ hexo.extend.filter.register('after_post_render', function(data){
 
       $('img').each(function(){
 		// For windows style path, we replace '\' to '/'.
-        var src = $(this).attr('src').replace('\\', '/');
+        var src = $(this).attr('src')&&$(this).attr('src').replace('\\', '/');
         if(!/http[s]*.*|\/\/.*/.test(src) &&
            !/^\s*\//.test(src)) {
 		  // For "about" page, the first part of "src" can't be removed.


### PR DESCRIPTION
先判断，再替换， 修复 文章中 出现  `<img>`  标签报错的情况