### PR TITLE
support hexo-abbrlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ MacGesture2-Publish.md
 Make sure `post_asset_folder: true` in your `_config.yml`.
 
 Just use `![logo](logo.jpg)` to insert `logo.jpg`.
+
+# History
+
+2018-04-18: support hexo-abbrlink

--- a/index.js
+++ b/index.js
@@ -10,15 +10,21 @@ hexo.extend.filter.register('after_post_render', function(data){
   var config = hexo.config;
   if(config.post_asset_folder){
     var link = data.permalink;
-	var beginPos = getPosition(link, '/', 3) + 1;
-	// In hexo 3.1.1, the permalink of "about" page is like ".../about/index.html".
-	var endPos = link.lastIndexOf('/') + 1;
-    link = link.substring(beginPos, endPos);
+    var beginPos = getPosition(link, '/', 3) + 1;
+    // In hexo 3.1.1, the permalink of "about" page is like ".../about/index.html".
+    // if not with index.html endpos = link.lastIndexOf('.') + 1 support hexo-abbrlink
+    if(/.*\/index\.html$/.test(link)) {
+      var endPos = link.lastIndexOf('/');
+    }
+    else {
+      var endPos = link.lastIndexOf('.');
+    }
+    link = link.substring(beginPos, endPos) + '/';
 
     var toprocess = ['excerpt', 'more', 'content'];
     for(var i = 0; i < toprocess.length; i++){
       var key = toprocess[i];
- 
+
       var $ = cheerio.load(data[key], {
         ignoreWhitespace: false,
         xmlMode: false,
@@ -27,29 +33,30 @@ hexo.extend.filter.register('after_post_render', function(data){
       });
 
       $('img').each(function(){
-		if ($(this).attr('src')){
-			// For windows style path, we replace '\' to '/'.
-			var src = $(this).attr('src').replace('\\', '/');
-			if(!/http[s]*.*|\/\/.*/.test(src) &&
-			   !/^\s*\//.test(src)) {
-			  // For "about" page, the first part of "src" can't be removed.
-			  // In addition, to support multi-level local directory.
-			  var linkArray = link.split('/').filter(function(elem){
-				return elem != '';
-			  });
-			  var srcArray = src.split('/').filter(function(elem){
-				return elem != '' && elem != '.';
-			  });
-			  if(srcArray.length > 1)
-				srcArray.shift();
-			  src = srcArray.join('/');
-			  $(this).attr('src', config.root + link + src);
-			  console.info&&console.info("update link as:-->"+config.root + link + src);
-			}
-		}else{
-			console.info&&console.info("no src attr, skipped...");
-			console.info&&console.info($(this));
-		}
+        if ($(this).attr('src')){
+          // For windows style path, we replace '\' to '/'.
+          var src = $(this).attr('src').replace('\\', '/');
+          if(!(/http[s]*.*|\/\/.*/.test(src)
+            || /^\s+\//.test(src)
+            || /^\s*\/uploads|images\//.test(src))) {
+            // For "about" page, the first part of "src" can't be removed.
+            // In addition, to support multi-level local directory.
+            var linkArray = link.split('/').filter(function(elem){
+              return elem != '';
+            });
+            var srcArray = src.split('/').filter(function(elem){
+              return elem != '' && elem != '.';
+            });
+            if(srcArray.length > 1)
+            srcArray.shift();
+            src = srcArray.join('/');
+            $(this).attr('src', config.root + link + src);
+            console.info&&console.info("update link as:-->"+config.root + link + src);
+          }
+        }else{
+          console.info&&console.info("no src attr, skipped...");
+          console.info&&console.info($(this));
+        }
       });
       data[key] = $.html();
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-asset-image",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Give asset image in hexo a absolutely path automatically",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
当博客使用了hexo-abbrlink时，生成的图片地址不对，修改代码以支持abbrlink，并兼容旧模式。