### PR TITLE
修改了正则匹配表达式，解决了标题以‘http’开头而无法进行图片src更替的问题。

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,21 @@
-# hexo-asset-image
+# hexo-asset-image-fixed
 
+本仓库修复了原包在`文章标题出现[http]/[https]等关键词时会无法转换src`的问题
+
+This repository fix a bug that `Cannot transfer the property 'scr' when the title contains a keyword like[http]/[https]`
+
+由于提交[PR](https://github.com/dangxuandev/hexo-asset-image/pull/42)后原作者一直没有更新，暂时将此仓库作为新的npm包发布。
+
+Because of my [PR](https://github.com/dangxuandev/hexo-asset-image/pull/42) being ignored by the author, who seems will not maintain this repository anymore, I published this repository as the new npm package temporarily.
+
+自动将hexo中的图片资源替换为绝对路径
 
 Give asset image in hexo a absolutely path automatically
 
 # Usege
 
 ```shell
-npm install hexo-asset-image --save
+npm install hexo-asset-image-fixed --save
 ```
 
 # Example
@@ -19,6 +28,10 @@ MacGesture2-Publish
 MacGesture2-Publish.md
 ```
 
+确保网站配置`_config.yml`中选项设置为：`post_asset_folder: true`。
+
 Make sure `post_asset_folder: true` in your `_config.yml`.
+
+就可以直接使用`![logo](logo.jpg)`来插入图片`logo.jpg`啦。
 
 Just use `![logo](logo.jpg)` to insert `logo.jpg`.

--- a/index.js
+++ b/index.js
@@ -30,8 +30,7 @@ hexo.extend.filter.register('after_post_render', function(data){
 		if ($(this).attr('src')){
 			// For windows style path, we replace '\' to '/'.
 			var src = $(this).attr('src').replace('\\', '/');
-			if(!/http[s]*.*|\/\/.*/.test(src) &&
-			   !/^\s*\//.test(src)) {
+			if(!/^(((http|https|ftp|rtsp|mms)+:\/{2})|\/).+/.test(src)) {
 			  // For "about" page, the first part of "src" can't be removed.
 			  // In addition, to support multi-level local directory.
 			  var linkArray = link.split('/').filter(function(elem){

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "hexo-asset-image",
-  "version": "0.0.3",
-  "description": "Give asset image in hexo a absolutely path automatically",
+  "name": "hexo-asset-image-fixed",
+  "version": "0.0.5",
+  "description": "Give asset image in hexo a absolutely path automatically. See details on https://github.com/Core00077/hexo-asset-image",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -12,7 +12,7 @@
     "asset",
     "path"
   ],
-  "author": "codefalling",
+  "author": "core00077",
   "license": "MIT",
   "dependencies": {
     "cheerio": "^0.19.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-asset-image-fixed",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Give asset image in hexo a absolutely path automatically. See details on https://github.com/Core00077/hexo-asset-image",
   "main": "index.js",
   "scripts": {
@@ -15,6 +15,6 @@
   "author": "core00077",
   "license": "MIT",
   "dependencies": {
-    "cheerio": "^0.19.0"
+    "cheerio": "^1.0.0-rc.3"
   }
 }


### PR DESCRIPTION
感谢贡献代码，此次提交解决了代码中存在的bug：无法为标题以'http'开头的文章进行图片src替换。

我更新了正则表达式，经过测试已经修复bug。